### PR TITLE
Added shardId to PubgEntity

### DIFF
--- a/src/pubg-dotnet/Models/Base/PubgEntity.cs
+++ b/src/pubg-dotnet/Models/Base/PubgEntity.cs
@@ -6,5 +6,8 @@ namespace Pubg.Net
     {
         [JsonProperty("id")]
         public string Id { get; set; }
+
+        [JsonProperty("shardId")]
+        public string ShardId { get; set; }
     }
 }

--- a/src/pubg-dotnet/Models/Match/PubgMatch.cs
+++ b/src/pubg-dotnet/Models/Match/PubgMatch.cs
@@ -31,8 +31,5 @@ namespace Pubg.Net
 
         [JsonProperty("titleId")]
         public string TitleId { get; set; }
-
-        [JsonProperty("shardId")]
-        public string ShardId { get; set; }
     }
 }

--- a/src/pubg-dotnet/Models/Match/PubgParticipant.cs
+++ b/src/pubg-dotnet/Models/Match/PubgParticipant.cs
@@ -3,18 +3,12 @@ using System.Collections.Generic;
 
 namespace Pubg.Net
 {
-    public class PubgParticipant
+    public class PubgParticipant : PubgEntity
     {
-        [JsonProperty("id")]
-        public string Id { get; set; }
-
         [JsonProperty("stats")]
         public IEnumerable<PubgStat> Stats { get; set; }
 
         [JsonProperty("actor")]
         public string Actor { get; set; }
-
-        [JsonProperty("shardId")]
-        public string ShardId { get; set; }
     }
 }

--- a/src/pubg-dotnet/Models/Match/PubgRoster.cs
+++ b/src/pubg-dotnet/Models/Match/PubgRoster.cs
@@ -2,11 +2,8 @@
 
 namespace Pubg.Net
 {
-    public class PubgRoster
+    public class PubgRoster : PubgEntity
     {
-        [JsonProperty("id")]
-        public string Id { get; set; }
-
         [JsonProperty("team")]
         public PubgTeam Team { get; set; }
     }


### PR DESCRIPTION
Most objects seem to use shardId so I thought I'd add that to base, for things that don't use shardId aren't inheriting PubgEntity anyways, so this shouldn't affect anything.