### PR TITLE
Split player season for clarity

### DIFF
--- a/src/pubg-dotnet/Models/Players/PubgPlayerSeason.cs
+++ b/src/pubg-dotnet/Models/Players/PubgPlayerSeason.cs
@@ -1,27 +1,11 @@
 ﻿using Newtonsoft.Json;
 using Pubg.Net.Infrastructure.JsonConverters;
-using Pubg.Net.Models.Base;
-using Pubg.Net.Models.Stats;
 using System.Collections.Generic;
 
 namespace Pubg.Net
 {
-    public class PubgPlayerSeason : PubgEntity
-    {
-        [JsonProperty]
-        public PubgSeasonStats GameModeStats { get; set; }
-
-        [JsonProperty]
-        public PubgSeasonStats LifetimeStats { get; set; }
-
-        [JsonProperty("player")]
-        [JsonConverter(typeof(RelationshipIdConverter))]
-        public string PlayerId { get; set; }
-
-        [JsonProperty("season")]
-        [JsonConverter(typeof(RelationshipIdConverter))]
-        public string SeasonId { get; set; }
-
+    public class PubgPlayerSeason : PubgStatEntity
+    {        
         [JsonProperty("matchesSolo")]
         [JsonConverter(typeof(RelationshipIdConverter))]
         public IEnumerable<string> SoloMatchIds { get; set; }

--- a/src/pubg-dotnet/Models/Stats/PubgStatEntity.cs
+++ b/src/pubg-dotnet/Models/Stats/PubgStatEntity.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+using Pubg.Net.Infrastructure.JsonConverters;
+using Pubg.Net.Models.Base;
+using Pubg.Net.Models.Stats;
+
+namespace Pubg.Net
+{
+    public class PubgStatEntity : PubgEntity
+    {
+        [JsonProperty]
+        public PubgSeasonStats GameModeStats { get; set; }
+
+        [JsonProperty("player")]
+        [JsonConverter(typeof(RelationshipIdConverter))]
+        public string PlayerId { get; set; }
+
+        [JsonProperty("season")]
+        [JsonConverter(typeof(RelationshipIdConverter))]
+        public string SeasonId { get; set; }
+    }
+}

--- a/src/pubg-dotnet/Services/Players/PubgPlayerService.cs
+++ b/src/pubg-dotnet/Services/Players/PubgPlayerService.cs
@@ -56,24 +56,24 @@ namespace Pubg.Net
             return JsonConvert.DeserializeObject<IEnumerable<PubgPlayer>>(collectionJson, new JsonApiSerializerSettings());
         }
 
-        public virtual PubgPlayerSeason GetPlayerLifetimeStats(PubgPlatform platform, string playerId, string apiKey = null)
+        public virtual PubgStatEntity GetPlayerLifetimeStats(PubgPlatform platform, string playerId, string apiKey = null)
         {
             var url = Api.Players.PlayerSeasonsEndpoint(platform, playerId, LIFETIME_SEASON_NAME);
             apiKey = string.IsNullOrEmpty(apiKey) ? ApiKey : apiKey;
 
             var seasonJson = HttpRequestor.GetString(url, apiKey);
 
-            return JsonConvert.DeserializeObject<PubgPlayerSeason>(seasonJson, new JsonApiSerializerSettings());
+            return JsonConvert.DeserializeObject<PubgStatEntity>(seasonJson, new JsonApiSerializerSettings());
         }
 
-        public virtual async Task<PubgPlayerSeason> GetPlayerLifetimeStatsAsync(PubgPlatform platform, string playerId, string apiKey = null, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<PubgStatEntity> GetPlayerLifetimeStatsAsync(PubgPlatform platform, string playerId, string apiKey = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var url = Api.Players.PlayerSeasonsEndpoint(platform, playerId, LIFETIME_SEASON_NAME);
             apiKey = string.IsNullOrEmpty(apiKey) ? ApiKey : apiKey;
 
             var seasonJson = await HttpRequestor.GetStringAsync(url, cancellationToken, apiKey).ConfigureAwait(false);
 
-            return JsonConvert.DeserializeObject<PubgPlayerSeason>(seasonJson, new JsonApiSerializerSettings());
+            return JsonConvert.DeserializeObject<PubgStatEntity>(seasonJson, new JsonApiSerializerSettings());
         }
 
         /// <summary>

--- a/test/pubg-dotnet.Tests/Players/PlayerTests.cs
+++ b/test/pubg-dotnet.Tests/Players/PlayerTests.cs
@@ -83,7 +83,7 @@ namespace Pubg.Net.Tests.Players
             playerSeason.GameModeStats.SquadFPP.Should().NotBeNull();
         }
 
-        //[Fact]
+        [Fact]
         public void Can_Get_LifetimeStats_For_Player_OnPC()
         {
             var playerService = new PubgPlayerService(Storage.ApiKey);
@@ -94,6 +94,7 @@ namespace Pubg.Net.Tests.Players
             var lifeTimeStats = playerService.GetPlayerLifetimeStats(PubgPlatform.Steam, playerId);
 
             lifeTimeStats.PlayerId.Should().BeEquivalentTo(playerId);
+            lifeTimeStats.SeasonId.Should().BeEquivalentTo("lifetime");
             lifeTimeStats.GameModeStats.Should().NotBeNull();
         }
 

--- a/test/pubg-dotnet.Tests/Players/PlayerTests.cs
+++ b/test/pubg-dotnet.Tests/Players/PlayerTests.cs
@@ -84,6 +84,19 @@ namespace Pubg.Net.Tests.Players
         }
 
         [Fact]
+        public void Can_Get_LifetimeStats_For_Player_OnPC()
+        {
+            var playerService = new PubgPlayerService(Storage.ApiKey);
+
+            var region = PubgRegion.PCEurope;
+            var playerId = Storage.GetMatch(region).Rosters.SelectMany(r => r.Participants).Select(p => p.Stats.PlayerId).FirstOrDefault();
+
+            var lifeTimeStats = playerService.GetPlayerLifetimeStats(PubgPlatform.Steam, playerId);
+
+            lifeTimeStats.PlayerId.Should().BeEquivalentTo(playerId);
+            lifeTimeStats.GameModeStats.Should().NotBeNull();
+        }
+
         public void Can_Get_Season_For_Player_OnXbox()
         {
             var playerService = new PubgPlayerService(Storage.ApiKey);


### PR DESCRIPTION
Updated:
- Split PubgPlayerSeason to two objects for clarity when viewing Lifetime Stats