### PR TITLE
Map "Baltic_Main" is missing from PubgMap enum

### DIFF
--- a/src/pubg-dotnet/Models/Match/PubgGameMode.cs
+++ b/src/pubg-dotnet/Models/Match/PubgGameMode.cs
@@ -33,6 +33,58 @@ namespace Pubg.Net
         [EnumMember(Value = "normal-squad")]
         NormalSquad,
         [EnumMember(Value = "normal-squad-fpp")]
-        NormalSquadFPP
+        NormalSquadFPP,
+
+        [EnumMember(Value = "conquest-duo")]
+        ConquestDuo,
+        [EnumMember(Value = "conquest-duo-fpp")]
+        ConquestDuoFPP,
+        [EnumMember(Value = "conquest-solo")]
+        ConquestSolo,
+        [EnumMember(Value = "conquest-solo-fpp")]
+        ConquestSoloFPP,
+        [EnumMember(Value = "conquest-squad")]
+        ConquestSquad,
+        [EnumMember(Value = "conquest-squad-fpp")]
+        ConquestSquadFPP,
+
+        [EnumMember(Value = "esports-duo")]
+        EsportsDuo,
+        [EnumMember(Value = "esports-duo-fpp")]
+        EsportsDuoFPP,
+        [EnumMember(Value = "esports-solo")]
+        EsportsSolo,
+        [EnumMember(Value = "esports-solo-fpp")]
+        EsportsSoloFPP,
+        [EnumMember(Value = "esports-squad")]
+        EsportsSquad,
+        [EnumMember(Value = "esports-squad-fpp")]
+        EsportsSquadFPP,
+
+        [EnumMember(Value = "war-duo")]
+        WarDuo,
+        [EnumMember(Value = "war-duo-fpp")]
+        WarDuoFPP,
+        [EnumMember(Value = "war-solo")]
+        WarSolo,
+        [EnumMember(Value = "war-solo-fpp")]
+        WarSoloFPP,
+        [EnumMember(Value = "war-squad")]
+        WarSquad,
+        [EnumMember(Value = "war-squad-fpp")]
+        WarSquadFPP,
+
+        [EnumMember(Value = "zombie-duo")]
+        ZombieDuo,
+        [EnumMember(Value = "zombie-duo-fpp")]
+        ZombieDuoFPP,
+        [EnumMember(Value = "zombie-solo")]
+        ZombieSolo,
+        [EnumMember(Value = "zombie-solo-fpp")]
+        ZombieSoloFPP,
+        [EnumMember(Value = "zombie-squad")]
+        ZombieSquad,
+        [EnumMember(Value = "zombie-squad-fpp")]
+        ZombieSquadFPP
     }
 }

--- a/src/pubg-dotnet/Models/Match/PubgMap.cs
+++ b/src/pubg-dotnet/Models/Match/PubgMap.cs
@@ -20,6 +20,8 @@ namespace Pubg.Net
         [EnumMember(Value = "Range_Main")]
         TrainingRange,
         [EnumMember(Value = "DihorOtok_Main")]
-        Vikendi
+        Vikendi,
+        [EnumMember(Value = "Baltic_Main")]
+        Baltic
     }
 }

--- a/src/pubg-dotnet/pubg-dotnet.csproj
+++ b/src/pubg-dotnet/pubg-dotnet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Sync and Async client library for communicating with the Pubg Developer API supporting .net standard 2.0</Description>
     <AssemblyTitle>Pubg.Net</AssemblyTitle>
-    <Version>2.2.0</Version>
+    <Version>2.2.1</Version>
     <Authors>Gavin Power</Authors>
     <TargetFramework>netstandard2.0;net45</TargetFramework>
     <AssemblyName>Pubg.Net</AssemblyName>

--- a/src/pubg-dotnet/pubg-dotnet.csproj
+++ b/src/pubg-dotnet/pubg-dotnet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Sync and Async client library for communicating with the Pubg Developer API supporting .net standard 2.0</Description>
     <AssemblyTitle>Pubg.Net</AssemblyTitle>
-    <Version>2.3.0</Version>
+    <Version>2.3.1</Version>
     <Authors>Gavin Power</Authors>
     <TargetFramework>netstandard2.0;net45</TargetFramework>
     <AssemblyName>Pubg.Net</AssemblyName>


### PR DESCRIPTION
The remastered Erangel map has been renamed and is reported as "Baltic_Main" in the JSON; it gets translated into Unspecified. Added enum member Baltic.