### PR TITLE
Support Clans endpoint

### DIFF
--- a/src/pubg-dotnet/Models/Clans/PubgClan.cs
+++ b/src/pubg-dotnet/Models/Clans/PubgClan.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using Pubg.Net.Models.Base;
+
+namespace Pubg.Net.Models.Clans;
+
+public class PubgClan : PubgEntity
+{
+    [JsonProperty("clanName")]
+    public string ClanName { get; set; }
+    
+    [JsonProperty("clanTag")]
+    public string ClanTag { get; set; }
+    
+    [JsonProperty("clanLevel")]
+    public string ClanLevel { get; set; }
+    
+    [JsonProperty("clanMemberCount")]
+    public string ClanMemberCount { get; set; }
+}

--- a/src/pubg-dotnet/Models/Players/PubgPlayer.cs
+++ b/src/pubg-dotnet/Models/Players/PubgPlayer.cs
@@ -29,5 +29,8 @@ namespace Pubg.Net
         
         [JsonProperty]
         public string BanType { get; set; }
+        
+        [JsonProperty]
+        public string ClanId { get; set; }
     }
 }

--- a/src/pubg-dotnet/Services/Clans/PubgClansService.cs
+++ b/src/pubg-dotnet/Services/Clans/PubgClansService.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using JsonApiSerializer;
+using Newtonsoft.Json;
+using Pubg.Net.Infrastructure;
+using Pubg.Net.Models.Clans;
+using Pubg.Net.Values;
+
+namespace Pubg.Net.Services.Clans;
+
+public class PubgClansService : PubgService
+{
+    public PubgClansService(string apiKey) : base(apiKey) { }
+    
+    public virtual PubgClan GetClan(PubgPlatform platform, string clanId, string apiKey = null)
+    {
+        var url = Api.Clans.ClansEndpoint(platform, clanId);
+        apiKey = string.IsNullOrEmpty(apiKey) ? ApiKey : apiKey;
+        
+        var clanJson = HttpRequestor.GetString(url, apiKey);
+        
+        return JsonConvert.DeserializeObject<PubgClan>(clanJson, new JsonApiSerializerSettings());
+    }
+    
+    public virtual async Task<PubgClan> GetClanAsync(PubgPlatform platform, string clanId, string apiKey = null, CancellationToken cancellationToken = default(CancellationToken))
+    {
+        var url = Api.Clans.ClansEndpoint(platform, clanId);
+        apiKey = string.IsNullOrEmpty(apiKey) ? ApiKey : apiKey;
+
+        var clanJson = await HttpRequestor.GetStringAsync(url, cancellationToken, apiKey);
+
+        return JsonConvert.DeserializeObject<PubgClan>(clanJson, new JsonApiSerializerSettings());
+    }
+}

--- a/src/pubg-dotnet/Values/Api.cs
+++ b/src/pubg-dotnet/Values/Api.cs
@@ -82,5 +82,11 @@ namespace Pubg.Net.Values
             internal static string SurvivalMasteryEndpoint(PubgPlatform platform, string accountId) =>
                 string.Format($"{ShardedBaseUrl}/players/{accountId}/survival_mastery", platform.Serialize());
         }
+
+        internal static class Clans
+        {
+            internal static string ClansEndpoint(PubgPlatform platform, string clanId) =>
+                string.Format($"{ShardedBaseUrl}/clans/{clanId}", platform.Serialize());
+        }
     }
 }

--- a/src/pubg-dotnet/pubg-dotnet.csproj
+++ b/src/pubg-dotnet/pubg-dotnet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Sync and Async client library for communicating with the Pubg Developer API supporting .net standard 2.0</Description>
     <AssemblyTitle>Pubg.Net</AssemblyTitle>
-    <Version>2.3.1</Version>
+    <Version>2.3.2</Version>
     <Authors>Gavin Power</Authors>
     <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Pubg.Net</AssemblyName>

--- a/test/pubg-dotnet.Tests/Clans/ClansTests.cs
+++ b/test/pubg-dotnet.Tests/Clans/ClansTests.cs
@@ -1,0 +1,22 @@
+﻿using Pubg.Net;
+using Pubg.Net.Services.Clans;
+using Pubg.Net.Tests.Util;
+using Xunit;
+
+namespace pubg.net.Tests.Clans;
+
+public class ClansTests : TestBase
+{
+    [Fact(Skip = "ClanIds are always null in the samples")]
+    public void Can_Get_Clans_ById()
+    {
+        var clansService = new PubgClansService(Storage.ApiKey);
+
+        var clanId = Storage.GetPlayer(PubgPlatform.Steam).ClanId;
+        
+        var clan = clansService.GetClan(PubgPlatform.Steam, clanId);
+        
+        Assert.NotNull(clan);
+        Assert.Equal(clanId, clan.Id);
+    }
+}


### PR DESCRIPTION
This PR introduces the ClansService, so the /clans endpoint can be supported in this package.
Please note that I debugged the new skipped test, and as I stated in the attribute, the sample players don't have clans so their "clanId" fields are null.